### PR TITLE
Add minus jacobian

### DIFF
--- a/pynav/filters.py
+++ b/pynav/filters.py
@@ -156,7 +156,9 @@ class ExtendedKalmanFilter:
         if y.stamp is not None:
             dt = y.stamp - x.state.stamp
             if dt < 0:
-                raise RuntimeError("Measurement stamp is earlier than state stamp")
+                raise RuntimeError(
+                    "Measurement stamp is earlier than state stamp"
+                )
             elif u is not None:
                 x = self.predict(x, u, dt)
 
@@ -198,7 +200,13 @@ class IteratedKalmanFilter(ExtendedKalmanFilter):
     On-manifold iterated extended Kalman filter.
     """
 
-    __slots__ = ["process_model", "reject_outliers", "step_tol", "max_iters"]
+    __slots__ = [
+        "process_model",
+        "reject_outliers",
+        "step_tol",
+        "max_iters",
+        "line_search",
+    ]
 
     def __init__(
         self,
@@ -212,6 +220,7 @@ class IteratedKalmanFilter(ExtendedKalmanFilter):
         self.step_tol = step_tol
         self.max_iters = max_iters
         self.reject_outliers = reject_outliers
+        self.line_search = line_search
 
     def correct(
         self,
@@ -262,7 +271,9 @@ class IteratedKalmanFilter(ExtendedKalmanFilter):
         if y.stamp is not None:
             dt = y.stamp - x.state.stamp
             if dt < 0:
-                raise RuntimeError("Measurement stamp is earlier than state stamp")
+                raise RuntimeError(
+                    "Measurement stamp is earlier than state stamp"
+                )
             elif dt > 0 and u is not None:
                 x = self.predict(x, u, dt)
 
@@ -304,16 +315,22 @@ class IteratedKalmanFilter(ExtendedKalmanFilter):
                 break
 
             # Perform backtracking line search
-            alpha = 1
-            cost_new = cost_old + 9999
-            step_accepted = False
-            while not step_accepted and alpha > self.step_tol:
-                x_new = x_op.plus(alpha * dx)
-                cost_new = self._get_cost_and_info(x_new, x, y, x_jac)["cost"]
-                if cost_new < cost_old:
-                    step_accepted = True
-                else:
-                    alpha *= 0.9
+            if self.line_search:
+                alpha = 1
+                cost_new = cost_old + 9999
+                step_accepted = False
+                while not step_accepted and alpha > self.step_tol:
+                    x_new = x_op.plus(alpha * dx)
+                    cost_new = self._get_cost_and_info(x_new, x, y, x_jac)[
+                        "cost"
+                    ]
+                    if cost_new < cost_old:
+                        step_accepted = True
+                    else:
+                        alpha *= 0.9
+            else:
+                x_new = x_op.plus(dx)
+                cost_new = cost_old
 
             # If step was not accepted, exit loop and do not update step
             if not step_accepted:
@@ -347,7 +364,7 @@ class IteratedKalmanFilter(ExtendedKalmanFilter):
         y_check = y.model.evaluate(x_op)
         z = y.value.reshape((-1, 1)) - y_check.reshape((-1, 1))
         e = x_op.minus(x_check.state).reshape((-1, 1))
-        J = x_op.jacobian(e)
+        J = x_op.plus_jacobian(e)
         P = J @ x_check.covariance @ J.T
         P = 0.5 * (P + P.T)
         cost_prior = np.ndarray.item(0.5 * e.T @ np.linalg.solve(P, e))
@@ -420,7 +437,9 @@ def run_filter(
 
         # Fuse any measurements that have occurred.
         if len(meas_data) > 0:
-            while y.stamp < input_data[k + 1].stamp and meas_idx < len(meas_data):
+            while y.stamp < input_data[k + 1].stamp and meas_idx < len(
+                meas_data
+            ):
 
                 x = filter.correct(x, y, u)
                 meas_idx += 1

--- a/pynav/imm.py
+++ b/pynav/imm.py
@@ -76,7 +76,7 @@ def reparametrize_gaussians_about_X_par(
 
     for X in X_list:
         mu = X.state.minus(X_par)
-        J = X_par.jacobian(mu)
+        J = X_par.plus_jacobian(mu)
         Sigma = J @ X.covariance @ J.T
         means_reparametrized.append(mu)
         covariances_reparametrized.append(Sigma)
@@ -106,7 +106,7 @@ def update_X(X: State, mu: np.ndarray, P: np.ndarray):
     X_hat = StateWithCovariance(X, np.zeros((X.dof, X.dof)))
     X_hat.state = X_hat.state.plus(mu)
 
-    J = X.jacobian(mu)
+    J = X.plus_jacobian(mu)
 
     X_hat.covariance = J @ P @ J.T
 

--- a/pynav/types.py
+++ b/pynav/types.py
@@ -107,14 +107,14 @@ class State(ABC):
         pass
 
 
-    def jacobian(self, dx: np.ndarray) -> np.ndarray:
+    def plus_jacobian(self, dx: np.ndarray) -> np.ndarray:
         """
         Jacobian of the `plus` operator. For Lie groups, this is known as the
         *group Jacobian*.
         """
         return np.identity(self.dof)
 
-    def jacobian_fd(self, dx) -> np.ndarray:
+    def plus_jacobian_fd(self, dx) -> np.ndarray:
         """
         Calculates the model jacobian with finite difference.
         """
@@ -130,6 +130,33 @@ class State(ABC):
 
         return jac_fd
 
+    def minus_jacobian(self, x: "State") -> np.ndarray:
+        """
+        Jacobian of the `minus` operator with respect to self. That is, if
+
+            y = x1.minus(x2)
+
+        then this is the Jacobian of `y` with respect to `x1`.        
+        For Lie groups, this is the inverse of the *group Jacobian* evaluated at
+        `dx = x1.minus(x2)`.
+        """
+        return np.identity(self.dof)
+
+    def minus_jacobian_fd(self, x: "State") -> np.ndarray:
+        """
+        Calculates the model jacobian with finite difference.
+        """
+        x_bar = x
+        jac_fd = np.zeros((self.dof, self.dof))
+        h = 1e-8
+        y_bar = self.minus(x_bar)
+        for i in range(self.dof):
+            dx = np.zeros((self.dof,))
+            dx[i] = h
+            y: State = self.plus(dx).minus(x_bar)
+            jac_fd[:, i] = (y - y_bar).flatten() / h
+
+        return jac_fd
 
 
 class MeasurementModel(ABC):

--- a/tests/unit/test_composite.py
+++ b/tests/unit/test_composite.py
@@ -18,15 +18,23 @@ def test_composite_process_model():
     jac_fd = process_model.jacobian_fd(x0, u, dt)
     assert np.allclose(jac, jac_fd, atol=1e-6)
 
-def test_composite_jacobian():
+def test_composite_plus_jacobian():
     T12 = SE2State(SE2.Exp([0.5, 1, -1]), stamp=0.0, state_id=2)
     T13 = SE2State(SE2.Exp([-0.5, 1, 1]), stamp=0.0, state_id=3)
     x = CompositeState([T12, T13])
     dx = np.array([i for i in range(x.dof)])
-    jac = x.jacobian(dx)
-    jac_fd = x.jacobian_fd(dx)
+    jac = x.plus_jacobian(dx)
+    jac_fd = x.plus_jacobian_fd(dx)
     assert np.allclose(jac, jac_fd, atol=1e-6)
 
+def test_composite_minus_jacobian():
+    T12 = SE2State(SE2.Exp([0.5, 1, -1]), stamp=0.0, state_id=2)
+    T13 = SE2State(SE2.Exp([-0.5, 1, 1]), stamp=0.0, state_id=3)
+    x1 = CompositeState([T12, T13])
+    x2 = CompositeState([T13, T12])
+    jac = x1.minus_jacobian(x2)
+    jac_fd = x1.minus_jacobian_fd(x2)
+    assert np.allclose(jac, jac_fd, atol=1e-6)
 
 def test_range_relative_pose():
 
@@ -55,4 +63,4 @@ def test_composite_pickling():
 
 
 if __name__ == "__main__":
-    test_composite_pickling()
+    test_composite_minus_jacobian()

--- a/tests/unit/test_imu.py
+++ b/tests/unit/test_imu.py
@@ -163,8 +163,8 @@ def test_imu_group_jacobian_right():
         direction="right",
     )
     dx = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 0.1, 0.2, 0.3, 4, 5, 6])
-    jac = x.jacobian(dx)
-    jac_fd = x.jacobian_fd(dx)
+    jac = x.plus_jacobian(dx)
+    jac_fd = x.plus_jacobian_fd(dx)
     assert np.allclose(jac, jac_fd, atol=1e-6)
 
 
@@ -177,8 +177,8 @@ def test_imu_group_jacobian_left():
         direction="left",
     )
     dx = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 0.1, 0.2, 0.3, 4, 5, 6])
-    jac = x.jacobian(dx)
-    jac_fd = x.jacobian_fd(dx)
+    jac = x.plus_jacobian(dx)
+    jac_fd = x.plus_jacobian_fd(dx)
     assert np.allclose(jac, jac_fd, atol=1e-6)
 
 def test_bias_jacobian_term():

--- a/tests/unit/test_states.py
+++ b/tests/unit/test_states.py
@@ -11,7 +11,7 @@ except ImportError:
     pass  # ROS is not installed
 except:
     raise
-
+np.set_printoptions(precision=5, suppress=True, linewidth=200)
 def test_plus_minus_vector():
     x1 = VectorState([1,2,3])
     dx = np.array([4,5,6])
@@ -74,39 +74,39 @@ def test_so3_ros():
     assert x.state_id == x2.state_id
     assert x.state_id == x_ros.header.frame_id
 
-def test_jacobian_vector():
+def test_plus_jacobian_vector():
     x1 = VectorState([1,2,3])
     dx = np.array([4,5,6])
-    jac = x1.jacobian(dx)
-    jac_test = x1.jacobian_fd(dx)
+    jac = x1.plus_jacobian(dx)
+    jac_test = x1.plus_jacobian_fd(dx)
     assert np.allclose(jac, jac_test, atol=1e-8)
 
-def test_jacobian_se3():
+def test_plus_jacobian_se3():
     x1 = SE3State(SE3.Exp([0.1,0.2,0.3,4,5,6]))
     dx = np.array([0.1, 0.2, 0.4, 0.2, 0.2, 0.2])
-    jac = x1.jacobian(dx)
-    jac_test = x1.jacobian_fd(dx)
+    jac = x1.plus_jacobian(dx)
+    jac_test = x1.plus_jacobian_fd(dx)
     assert np.allclose(jac, jac_test, atol=1e-8)
 
-def test_jacobian_se2():
+def test_plus_jacobian_se2():
     x1 = SE2State(SE2.Exp([0.1,5,6]))
     dx = np.array([0.1, 0.2, 0.4])
-    jac = x1.jacobian(dx)
-    jac_test = x1.jacobian_fd(dx)
+    jac = x1.plus_jacobian(dx)
+    jac_test = x1.plus_jacobian_fd(dx)
     assert np.allclose(jac, jac_test, atol=1e-8)
 
-def test_jacobian_so2():
+def test_plus_jacobian_so2():
     x1 = SO2State(SO2.Exp([0.1]))
     dx = np.array([0.3])
-    jac = x1.jacobian(dx)
-    jac_test = x1.jacobian_fd(dx)
+    jac = x1.plus_jacobian(dx)
+    jac_test = x1.plus_jacobian_fd(dx)
     assert np.allclose(jac, jac_test, atol=1e-8)
 
-def test_jacobian_so3():
+def test_plus_jacobian_so3():
     x1 = SO3State(SO3.Exp([0.1, 0.2, 0.3]))
     dx = np.array([0.3, 0.4, 0.5])
-    jac = x1.jacobian(dx)
-    jac_test = x1.jacobian_fd(dx)
+    jac = x1.plus_jacobian(dx)
+    jac_test = x1.plus_jacobian_fd(dx)
     assert np.allclose(jac, jac_test, atol=1e-8)
 
 def test_plus_minus_sl3():
@@ -116,5 +116,41 @@ def test_plus_minus_sl3():
     dx_test = x2.minus(x1)
     assert np.allclose(dx,dx_test, atol=1e-8)
 
+def test_minus_jacobian_vector():
+    x1 = VectorState([1,2,3])
+    x2 = VectorState([4,5,6])
+    jac = x1.minus_jacobian(x2)
+    jac_test = x1.minus_jacobian_fd(x2)
+    assert np.allclose(jac, jac_test, atol=1e-8)
+
+def test_minus_jacobian_se3():
+    x1 = SE3State(SE3.Exp([0.1,0.2,0.3,4,5,6]))
+    x2 = SE3State(SE3.Exp([0.1,0.2,0.4,0.2,0.2,0.2]))
+    jac = x1.minus_jacobian(x2)
+    jac_test = x1.minus_jacobian_fd(x2)
+    assert np.allclose(jac, jac_test, atol=1e-5)
+
+def test_minus_jacobian_se2():
+    x1 = SE2State(SE2.Exp([0.1,5,6]))
+    x2 = SE2State(SE2.Exp([0.1,0.2,0.4]))
+    jac = x1.minus_jacobian(x2)
+    jac_test = x1.minus_jacobian_fd(x2)
+    assert np.allclose(jac, jac_test, atol=1e-6)
+
+def test_minus_jacobian_so2():
+    x1 = SO2State(SO2.Exp([0.1]))
+    x2 = SO2State(SO2.Exp([0.3]))
+    jac = x1.minus_jacobian(x2)
+    jac_test = x1.minus_jacobian_fd(x2)
+    assert np.allclose(jac, jac_test, atol=1e-8)
+
+def test_minus_jacobian_so3():
+    x1 = SO3State(SO3.Exp([0.1, 0.2, 0.3]))
+    x2 = SO3State(SO3.Exp([0.3, 0.4, 0.5]))
+    jac = x1.minus_jacobian(x2)
+    jac_test = x1.minus_jacobian_fd(x2)
+    assert np.allclose(jac, jac_test, atol=1e-8)
+
+
 if __name__ == "__main__":
-    test_jacobian_so2()
+    test_minus_jacobian_se2()


### PR DESCRIPTION
Just like algorithms fundamentally need access to the plus() jacobian, they also need access to the minus() jacobian, which is coincidentally the inverse of the plus jacobian for lie groups. 

This was added as an abstract method to `State` and corresponding fixes were made everywhere. `State` now has `plus_jacobian(dx)` , `minus_jacobian(x)` as well as finite-difference counterparts `plus_jacobian_fd(dx)` , `minus_jacobian_fd(x)`

Note: Ceres also has this: http://ceres-solver.org/nnls_modeling.html#_CPPv4NK5ceres13MinusJacobianEPKdPd