### PR TITLE
Bugfix: Flatten innovation in IMM

### DIFF
--- a/pynav/imm.py
+++ b/pynav/imm.py
@@ -343,6 +343,7 @@ class InteractingModelFilter:
             x_hat.append(x)
             z = details_dict["z"]
             S = details_dict["S"]
+            z = z.ravel()
             model_likelihood = multivariate_normal.pdf(z, mean=np.zeros(z.shape), cov=S)
             mu_k[lv1] = model_likelihood * c_bar[lv1]
 


### PR DESCRIPTION
Sometimes z is provided as a column matrix which causes a bug. This fixes those cases. 